### PR TITLE
feat: use app-channel-address

### DIFF
--- a/chart/dapr-ambient/templates/_daemondeployshared.yaml
+++ b/chart/dapr-ambient/templates/_daemondeployshared.yaml
@@ -53,6 +53,8 @@
           command: ['/bin/sh', "-c"]
           args:
           - 
+            echo "Waiting dapr-ambient...";
+            sleep 10s;
             export DAPR_TRUST_ANCHORS=`cat /shared/DAPR_TRUST_ANCHORS`;
             export DAPR_CERT_CHAIN=`cat /shared/DAPR_CERT_CHAIN`;
             export DAPR_CERT_KEY=`cat /shared/DAPR_CERT_KEY`;
@@ -73,7 +75,8 @@
                   --enable-metrics={{ .Values.ambient.daprd.metrics.enabled }}
                   --metrics-port={{ .Values.ambient.daprd.metrics.port }}
                   --enable-mtls={{ .Values.ambient.daprd.mtls.enabled }}
-                  --enable-api-logging={{ .Values.ambient.daprd.apiLogging.enabled }};
+                  --enable-api-logging={{ .Values.ambient.daprd.apiLogging.enabled }}
+                  --app-channel-address="{{ .Values.ambient.proxy.remoteURL }}";
           env:
           - name: DAPR_CONTROL_PLANE_NAMESPACE
             value: {{ default "dapr-system" .Values.ambient.controlPlane.namespace }}

--- a/chart/dapr-ambient/tests/daemonset_test.yaml
+++ b/chart/dapr-ambient/tests/daemonset_test.yaml
@@ -247,14 +247,17 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[1].args[0]
-          pattern: ^export DAPR_TRUST_ANCHORS=`cat /shared/DAPR_TRUST_ANCHORS`; export DAPR_CERT_CHAIN=`cat
+          pattern: ^echo "Waiting dapr-ambient...";
+            sleep 10s;
+            export DAPR_TRUST_ANCHORS=`cat /shared/DAPR_TRUST_ANCHORS`; export DAPR_CERT_CHAIN=`cat
               /shared/DAPR_CERT_CHAIN`; export DAPR_CERT_KEY=`cat /shared/DAPR_CERT_KEY`; ./daprd
               --mode=kubernetes --log-level=info --log-as-json=true --dapr-http-port=3500 --dapr-grpc-port=50001
               --dapr-internal-grpc-port=50002 --dapr-listen-addresses=0.0.0.0 --dapr-public-port=3501
               --app-id=appId --app-port="8080" --app-protocol="http" --control-plane-address=dapr-api.dapr-system.svc.cluster.local:80
               --placement-host-address=dapr-placement-server.dapr-system.svc.cluster.local:50005
               --sentry-address= --enable-metrics=true --metrics-port=9090 --enable-mtls=false
-              --enable-api-logging=true;$
+              --enable-api-logging=true
+              --app-channel-address="https://local";$
       - matchRegex:
           path: spec.template.spec.containers[1].args[0]
           pattern: \s--log-level=info\s
@@ -308,7 +311,10 @@ tests:
           pattern: \s--enable-mtls=false\s
       - matchRegex:
           path: spec.template.spec.containers[1].args[0]
-          pattern: \s--enable-api-logging=true;$
+          pattern: \s--enable-api-logging=true\s
+      - matchRegex:
+          path: spec.template.spec.containers[1].args[0]
+          pattern: \s--app-channel-address="https://local";$
 
   - it: should fail when ambient.daprd.app.port is empty
     values:

--- a/daprd/Dockerfile
+++ b/daprd/Dockerfile
@@ -1,2 +1,5 @@
-FROM daprio/daprd:1.9.6
-COPY --from=busybox:1.28 /bin/sh /bin/sh
+FROM daprio/daprd:1.11.0-rc.5 as builder
+
+FROM alpine:latest
+
+COPY --from=builder daprd daprd


### PR DESCRIPTION
Fixes: #14 


This pull request adds `--app-channel-address` instead redirecting request from `dapr-ambient` manually.

Is important to know that this features will be released on version `1.11.0`.

Now, the main dapr-ambient goal is to configure `daprd` getting credentials.

## How-to test 

Build dapr-ambient-proxy image:

```
go build main.go
```

Build the image:
```
docker build -t <username>/<tag>
```

Build the `daprd` image:

```
cd daprd
docker build -t <username>/<tag>
```
Change the values.yaml file package and follow this tutorial:

Install redis:
```
  kind create cluster --name dapr-ambient
```

```
helm install redis bitnami/redis --set image.tag=6.2 --set architecture=standalone
```

Install dapr:
```
  helm upgrade --install dapr dapr/dapr \
  --version=1.10.4 \
  --namespace dapr-system \
  --create-namespace \
  --wait
```

Install all components:
```
kubectl apply -f - <<EOF
apiVersion: dapr.io/v1alpha1
kind: Component
metadata:
  name: statestore
spec:
  type: state.redis
  version: v1
  metadata:
  - name: keyPrefix
    value: name
  - name: redisHost
    value: redis-master:6379
  - name: redisPassword
    secretKeyRef:
      name: redis
      key: redis-password
auth:
  secretStore: kubernetes
EOF
```
```
kubectl apply -f - <<EOF
apiVersion: dapr.io/v1alpha1
kind: Component
metadata:
  name: notifications-pubsub
spec:
  type: pubsub.redis
  version: v1
  metadata:
  - name: redisHost
    value: redis-master:6379
  - name: redisPassword
    secretKeyRef:
      name: redis
      key: redis-password
auth:
  secretStore: kubernetes
EOF
```

```
kubectl apply -f - <<EOF
apiVersion: dapr.io/v1alpha1
kind: Subscription
metadata:
  name: notifications-subscription
spec:
  topic: notifications 
  route: /notifications
  pubsubname: notifications-pubsub
EOF
```

Create all apps:
```
  kubectl apply -f https://raw.githubusercontent.com/salaboy/dapr-ambient-examples/main/apps.yaml
```

Build and run dapr-ambient:

```
  helm package  chart/dapr-ambient
  helm install my-ambient-dapr-ambient dapr-ambient-1.9.5.tgz --set ambient.appId=my-dapr-app --set ambient.proxy.remoteURL=subscriber-svc
```

