### PR TITLE
feat: package & publish helm chart via dapr standard

### DIFF
--- a/.github/scripts/get_release_version.py
+++ b/.github/scripts/get_release_version.py
@@ -1,0 +1,54 @@
+#
+# Copyright 2021 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script parses release version from Git tag and set the parsed version to
+# environment variable, REL_VERSION. If the tag is the final version, it sets
+# LATEST_RELEASE to true to add 'latest' tag to docker image.
+
+import os
+import sys
+import datetime
+
+gitRef = os.getenv("GITHUB_REF")
+tagRefPrefix = "refs/tags/v"
+
+with open(os.getenv("GITHUB_ENV"), "a") as githubEnv:
+
+    if "schedule" in sys.argv:
+        dateTag = datetime.datetime.utcnow().strftime("%Y-%m-%d")
+        githubEnv.write("REL_VERSION=nightly-{}\n".format(dateTag))
+        print ("Nightly release build nightly-{}".format(dateTag))
+        sys.exit(0)
+
+    if gitRef is None or not gitRef.startswith(tagRefPrefix):
+        githubEnv.write("REL_VERSION=edge\n")
+        print ("This is daily build from {}...".format(gitRef))
+        sys.exit(0)
+
+    releaseVersion = gitRef[len(tagRefPrefix):]
+    releaseNotePath="docs/release_notes/v{}.md".format(releaseVersion)
+
+    if gitRef.find("-rc.") > 0:
+        print ("Release Candidate build from {}...".format(gitRef))
+    else:
+        print ("Checking if {} exists".format(releaseNotePath))
+        if os.path.exists(releaseNotePath):
+            print ("Found {}".format(releaseNotePath))
+            # Set LATEST_RELEASE to true
+            githubEnv.write("LATEST_RELEASE=true\n")
+        else:
+            print ("{} is not found".format(releaseNotePath))
+            sys.exit(1)
+        print ("Release build from {}...".format(gitRef))
+
+    githubEnv.write("REL_VERSION={}\n".format(releaseVersion))

--- a/.github/scripts/set_helm_dapr_version.sh
+++ b/.github/scripts/set_helm_dapr_version.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Copyright 2021 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+replace_all() {
+  SUBSTRING=$1
+  CONTENT=$2
+  FILES=`grep -Hrl $SUBSTRING charts`
+  for file in $FILES; do
+    echo "Replacing \"$SUBSTRING\" with \"$CONTENT\" in $file ..."
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+      # Mac OSX
+      sed -i '' -e "s/$SUBSTRING/$CONTENT/" "$file"
+    else
+      # Linux
+      sed -e "s/$SUBSTRING/$CONTENT/" -i "$file"
+    fi
+  done
+}
+
+
+if [ -z $REL_VERSION ]; then
+  echo "REL_VERSION is not set. Exiting ..."
+  exit 1
+fi
+
+DAPR_VERSION_HELM="${REL_VERSION}"
+DAPR_VERSION_TAG="${REL_VERSION}"
+if [[ "$REL_VERSION" == "edge" || "$REL_VERSION" == "nightly"* ]]; then
+  DAPR_VERSION_HELM="0.0.0"
+fi
+
+replace_all "'edge'" "'$DAPR_VERSION_TAG'"
+replace_all "'0.0.0'" "'$DAPR_VERSION_HELM'"

--- a/.github/workflows/dapr-ambient-helm.yaml
+++ b/.github/workflows/dapr-ambient-helm.yaml
@@ -48,19 +48,19 @@ jobs:
           echo "REPO_OWNER=${REPO_OWNER,,}" >>${GITHUB_ENV}
       - name: Update Helm chart files for release version ${{ env.REL_VERSION }}
         run: bash ./.github/scripts/set_helm_dapr_version.sh
-    #   - name: Generate Helm chart manifest
-    #     if: env.DOCKER_REGISTRY != ''
-    #     env:
-    #       DAPR_REGISTRY: ${{ env.DOCKER_REGISTRY }}
-    #       DAPR_TAG: ${{ env.REL_VERSION }}
-    #     run: |
-    #       make manifest-gen
-    #     shell: bash
-    #   - name: Move Helm chart manifest to artifact
-    #     if: env.DOCKER_REGISTRY != ''
-    #     run: |
-    #       mkdir -p ${{ env.ARTIFACT_DIR }}
-    #       mv ./dist/install/dapr.yaml ${{ env.ARTIFACT_DIR }}/dapr-operator.yaml
+      - name: Generate Helm chart manifest
+        if: env.DOCKER_REGISTRY != ''
+        env:
+          DAPR_REGISTRY: ${{ env.DOCKER_REGISTRY }}
+          DAPR_TAG: ${{ env.REL_VERSION }}
+        run: |
+          make manifest-gen
+        shell: bash
+      - name: Move Helm chart manifest to artifact
+        if: env.DOCKER_REGISTRY != ''
+        run: |
+          mkdir -p ${{ env.ARTIFACT_DIR }}
+          mv ./dist/install/dapr.yaml ${{ env.ARTIFACT_DIR }}/dapr-operator.yaml
       - name: Save release version
         run: |
           mkdir -p ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}

--- a/.github/workflows/dapr-ambient-helm.yaml
+++ b/.github/workflows/dapr-ambient-helm.yaml
@@ -1,0 +1,136 @@
+#
+# Copyright 2021 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: dapr-ambient-helm
+
+on:
+  pull_request:
+
+permissions:
+    contents: write
+
+jobs:
+  helm:
+    name: Package Helm Chart
+            
+    env:
+      ARTIFACT_DIR: ./release
+      HELM_PACKAGE_DIR: chart/dapr-ambient
+      DAPR_VERSION_ARTIFACT: dapr_version
+      DOCKER_REGISTRY: ''
+      HELMVER: v3.7.2
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Helm ${{ env.HELMVER }}
+        uses: azure/setup-helm@v1
+        with:
+          version: ${{ env.HELMVER }}
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+      - name: Parse release version and set REL_VERSION and LATEST_RELEASE
+        run: python ./.github/scripts/get_release_version.py ${{ github.event_name }}
+      - name: Set REPO_OWNER
+        shell: bash
+        run: |
+          REPO_OWNER=${{ github.repository_owner }}
+          # Lowercase the value
+          echo "REPO_OWNER=${REPO_OWNER,,}" >>${GITHUB_ENV}
+      - name: Update Helm chart files for release version ${{ env.REL_VERSION }}
+        run: bash ./.github/scripts/set_helm_dapr_version.sh
+    #   - name: Generate Helm chart manifest
+    #     if: env.DOCKER_REGISTRY != ''
+    #     env:
+    #       DAPR_REGISTRY: ${{ env.DOCKER_REGISTRY }}
+    #       DAPR_TAG: ${{ env.REL_VERSION }}
+    #     run: |
+    #       make manifest-gen
+    #     shell: bash
+    #   - name: Move Helm chart manifest to artifact
+    #     if: env.DOCKER_REGISTRY != ''
+    #     run: |
+    #       mkdir -p ${{ env.ARTIFACT_DIR }}
+    #       mv ./dist/install/dapr.yaml ${{ env.ARTIFACT_DIR }}/dapr-operator.yaml
+      - name: Save release version
+        run: |
+          mkdir -p ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}
+          echo ${REL_VERSION} > ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}/${{ env.DAPR_VERSION_ARTIFACT }}
+      - name: Package Helm chart
+        if: ${{ env.LATEST_RELEASE }} == "true" && env.DOCKER_REGISTRY != ''
+        env:
+          HELM_CHARTS_DIR: charts/dapr
+        run: |
+          mkdir -p ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}
+          helm package ${{ env.HELM_CHARTS_DIR }} --destination ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}
+      - name: Upload Helm charts package to artifacts
+        if: ${{ env.LATEST_RELEASE }} == "true" && env.DOCKER_REGISTRY != ''
+        uses: actions/upload-artifact@master
+        with:
+          name: dapr_helm_charts_package
+          path: ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}
+          
+  # This job downloads the helm charts package artifact uploaded by the publish job,
+  # checks out the helm charts git hub pages repo and commits the latest version of
+  # helm charts package.
+  # This does not run on forks
+  helmpublish:
+    name: Publish helm charts to Helm github pages repo
+    needs: helm
+    if: startswith(github.ref, 'refs/tags/v') && github.repository_owner == 'dapr'
+    env:
+      ARTIFACT_DIR: ./release
+      DAPR_VERSION_ARTIFACT: dapr_version
+      HELM_PACKAGE_DIR: chart/dapr-ambient
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Helm charts directory
+        run: |
+          mkdir -p ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}
+      - name: download artifacts - dapr_helm_charts_package
+        uses: actions/download-artifact@master
+        with:
+          name: dapr_helm_charts_package
+          path: ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}
+      - name: Checkout Helm Charts Repo
+        uses: actions/checkout@v3
+        env:
+          DAPR_HELM_REPO: dapr/helm-charts
+          DAPR_HELM_REPO_CODE_PATH: helm-charts
+        with:
+          repository: ${{ env.DAPR_HELM_REPO }}
+          ref: refs/heads/master
+          token: ${{ secrets.DAPR_BOT_TOKEN }}
+          path: ${{ env.DAPR_HELM_REPO_CODE_PATH }}
+      - name: Upload helm charts to Helm Repo
+        env:
+          DAPR_HELM_REPO_CODE_PATH: helm-charts
+          DAPR_HELM_REPO: https://dapr.github.io/helm-charts/
+        run: |
+          daprVersion=`cat ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}/${{ env.DAPR_VERSION_ARTIFACT }}`
+          cd ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}
+          cp -r `ls -A | grep -v ${{ env.DAPR_VERSION_ARTIFACT }}` $GITHUB_WORKSPACE/${{ env.DAPR_HELM_REPO_CODE_PATH }}
+          cd $GITHUB_WORKSPACE/${{ env.DAPR_HELM_REPO_CODE_PATH }}
+          helm repo index --url ${{ env.DAPR_HELM_REPO }} --merge index.yaml .
+          git config --global user.email "daprweb@microsoft.com"
+          git config --global user.name "dapr-bot"
+          git add --all
+          # Check if the dapr-${daprVersion}.tgz file is modified.
+          if git diff --name-only --staged | grep -q ${daprVersion}; then
+            # If it is, we update the Helm chart, since this is an intentional update.
+            git commit -m "Release - $daprVersion"
+            git push
+          else
+            # If not, this update was accidentally triggered by tagging a release before updating the Helm chart.
+            echo "::error::There is no change for ${daprVersion} Helm chart. Did you forget to update the chart version before tagging?"
+            exit -1
+          fi


### PR DESCRIPTION
Creating a deployment for helm charts by following the example on dapr's main repo: https://github.com/dapr/dapr/blob/6220ab954a27b1c2e620a5060f1e056d653b3695/.github/workflows/dapr.yml#LL597C8-L597C8